### PR TITLE
MJ - DELETE ENDPOINT for Recommendation Request

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -113,6 +113,24 @@ public class RecommendationRequestController extends ApiController{
     }
 
     /**
+     * Delete a recommendation request
+     * 
+     * @param id the id of the recommendation request to delete
+     * @return a message indicating the recommedation request was deleted
+     */
+    @Operation(summary= "Delete a recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(recommendationRequest);
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+    }
+
+    /**
      * Update a single recommendation request
      * 
      * @param id       id of the recommendation request to update


### PR DESCRIPTION
## Closes #24 ##

**This pull request:**

- Implement Delete Endpoint for Recommendation Request Controller
- Added Tests for Delete Endpoint
- Works locally and on dokku
- Passes jacoco and mutation testing